### PR TITLE
feat: Add "Export CSV" functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -87,7 +87,8 @@
 
       <section class="mt-6 pt-5 border-t border-border">
         <div class="flex gap-2 flex-wrap">
-          <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="exportBtn" title="Export as JSON">Export</button>
+          <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="exportBtn" title="Export as JSON">Export JSON</button>
+          <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="exportCsvBtn" title="Export as CSV">Export CSV</button>
           <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="importBtn" title="Import from JSON">Import</button>
           <input type="file" id="fileInput" accept="application/json" hidden />
         </div>
@@ -261,6 +262,36 @@
         URL.revokeObjectURL(url);
       }
 
+      function exportCSV() {
+        const headers = ["id", "title", "completed", "createdAt", "dueAt"];
+
+        const escapeValue = (value) => {
+          if (value === null || value === undefined) {
+            return '';
+          }
+          const stringValue = String(value);
+          if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\\n')) {
+            return `"${stringValue.replace(/"/g, '""')}"`;
+          }
+          return stringValue;
+        };
+
+        const csvRows = [
+          headers.join(','),
+          ...state.todos.map(todo =>
+            headers.map(header => escapeValue(todo[header])).join(',')
+          )
+        ];
+
+        const blob = new Blob([csvRows.join('\\n')], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const $a = $('<a>').attr({ href: url, download: 'todos.csv' });
+        $('body').append($a);
+        $a[0].click();
+        $a.remove();
+        URL.revokeObjectURL(url);
+      }
+
       function importJSON(file) {
         const reader = new FileReader();
         reader.onload = function(e) {
@@ -314,6 +345,7 @@
       });
 
       $("#exportBtn").on('click', exportJSON);
+      $("#exportCsvBtn").on('click', exportCSV);
       
       $("#importBtn").on('click', function() {
         $("#fileInput").click();


### PR DESCRIPTION
This commit introduces a new feature that allows users to export their to-do list as a CSV file.

- Adds an "Export CSV" button next to the "Export JSON" button in the UI.
- Implements the `exportCSV` JavaScript function to handle the conversion of the to-do list data into a CSV format.
- The exported CSV file includes the headers: `id`, `title`, `completed`, `createdAt`, and `dueAt`.
- Ensures that values containing special characters (commas, quotes) are properly escaped.
- The downloaded file is named `todos.csv` and is UTF-8 encoded.